### PR TITLE
feat: Implement Phase-Based Regeneration System

### DIFF
--- a/frontend/src/components/AgentChat.tsx
+++ b/frontend/src/components/AgentChat.tsx
@@ -434,6 +434,25 @@ const AGENT_DEPENDENCIES: Record<AgentName, AgentName[]> = {
   Critic: ['Writer', 'Critic'],
 };
 
+const AGENT_TO_PHASE: Record<string, string> = {
+  'Architect': 'Genesis',
+  'Profiler': 'Characters',
+  'Worldbuilder': 'Worldbuilding',
+  'Strategist': 'Outlining',
+  'Writer': 'Drafting',
+  'Critic': 'Polish',
+  'Polish': 'Polish',
+};
+
+const PHASE_ORDER = ['Genesis', 'Characters', 'Worldbuilding', 'Outlining', 'Advanced Planning', 'Drafting', 'Polish'];
+
+const getPhasesToRegenerate = (editedAgent: string): string[] => {
+  const startPhase = AGENT_TO_PHASE[editedAgent] || 'Genesis';
+  const startIndex = PHASE_ORDER.indexOf(startPhase);
+  if (startIndex === -1) return PHASE_ORDER;
+  return PHASE_ORDER.slice(startIndex);
+};
+
 const AGENT_COLORS: Record<string, string> = {
   Architect: 'bg-blue-500',
   Profiler: 'bg-cyan-500',
@@ -1467,11 +1486,19 @@ export function AgentChat({ runId, orchestratorUrl, onComplete, onClose, project
                 You edited <span className={AGENT_TEXT_COLORS[pendingEdit.agent]}>{pendingEdit.agent}</span>. 
                 This will affect downstream agents.
               </p>
-              <div className="mt-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
-                <p className="text-xs text-amber-300">
-                  <strong>Note:</strong> Regeneration will start a new complete generation run. 
-                  Your edit will be used as context, but all scenes will be regenerated from scratch.
+              <div className="mt-3 p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg">
+                <p className="text-xs text-blue-300">
+                  <strong>Phase-Based Regeneration:</strong> Only phases from <span className="font-semibold">{AGENT_TO_PHASE[pendingEdit.agent] || 'Genesis'}</span> onwards will be regenerated.
+                  Previous phases will be preserved from your last run.
                 </p>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {getPhasesToRegenerate(pendingEdit.agent).map((phase, idx) => (
+                    <span key={phase} className="text-xs px-2 py-0.5 rounded bg-blue-500/20 text-blue-300">
+                      {idx > 0 && <span className="mr-1">→</span>}
+                      {phase}
+                    </span>
+                  ))}
+                </div>
               </div>
             </div>
             

--- a/supabase/migrations/003_create_run_artifacts_table.sql
+++ b/supabase/migrations/003_create_run_artifacts_table.sql
@@ -1,0 +1,71 @@
+-- Create run_artifacts table for storing phase outputs for phase-based regeneration
+-- This table stores artifacts from each phase of generation, allowing resumption from any phase
+CREATE TABLE IF NOT EXISTS run_artifacts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    run_id TEXT NOT NULL,
+    phase TEXT NOT NULL,
+    artifact_type TEXT NOT NULL,
+    content JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Create indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_run_artifacts_project_id ON run_artifacts(project_id);
+CREATE INDEX IF NOT EXISTS idx_run_artifacts_run_id ON run_artifacts(run_id);
+CREATE INDEX IF NOT EXISTS idx_run_artifacts_phase ON run_artifacts(phase);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_run_artifacts_run_phase_type ON run_artifacts(run_id, phase, artifact_type);
+
+-- Enable Row Level Security for run_artifacts
+ALTER TABLE run_artifacts ENABLE ROW LEVEL SECURITY;
+
+-- Create policy: Users can only see artifacts for their own projects
+CREATE POLICY "Users can view own project artifacts" ON run_artifacts
+    FOR SELECT USING (
+        EXISTS (
+            SELECT 1 FROM projects 
+            WHERE projects.id = run_artifacts.project_id 
+            AND projects.user_id = auth.uid()
+        )
+    );
+
+-- Create policy: Users can insert artifacts for their own projects
+CREATE POLICY "Users can insert own project artifacts" ON run_artifacts
+    FOR INSERT WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM projects 
+            WHERE projects.id = run_artifacts.project_id 
+            AND projects.user_id = auth.uid()
+        )
+    );
+
+-- Create policy: Users can update artifacts for their own projects
+CREATE POLICY "Users can update own project artifacts" ON run_artifacts
+    FOR UPDATE USING (
+        EXISTS (
+            SELECT 1 FROM projects 
+            WHERE projects.id = run_artifacts.project_id 
+            AND projects.user_id = auth.uid()
+        )
+    );
+
+-- Create policy: Users can delete artifacts for their own projects
+CREATE POLICY "Users can delete own project artifacts" ON run_artifacts
+    FOR DELETE USING (
+        EXISTS (
+            SELECT 1 FROM projects 
+            WHERE projects.id = run_artifacts.project_id 
+            AND projects.user_id = auth.uid()
+        )
+    );
+
+-- Grant permissions to authenticated users
+GRANT SELECT, INSERT, UPDATE, DELETE ON run_artifacts TO authenticated;
+
+-- Grant read permissions to anon (if needed later)
+GRANT SELECT ON run_artifacts TO anon;
+
+-- Add comment explaining the table
+COMMENT ON TABLE run_artifacts IS 'Stores phase outputs for each generation run, enabling phase-based regeneration';
+COMMENT ON COLUMN run_artifacts.phase IS 'Phase name: genesis, characters, worldbuilding, outlining, advanced_planning, drafting, polish';
+COMMENT ON COLUMN run_artifacts.artifact_type IS 'Type of artifact: narrative_possibility, characters, worldbuilding, outline, advanced_planning, draft_scene_N, polished_scene_N';


### PR DESCRIPTION
## Summary

This PR implements Option 2: Phase-Based Regeneration for the MANOE storytelling system. This feature allows users to edit agent outputs and resume generation from the earliest phase that must be recomputed, rather than starting a complete new run.

## Changes

### Backend (Orchestrator)

- **New Migration**: Added `run_artifacts` table for storing phase outputs per generation run
- **Supabase Persistence Service**: Extended with methods for storing/retrieving run artifacts
- **Autogen Orchestrator**: Added phase-based regeneration logic to `run_full_generation()`
- **Multi-Agent Worker**: Updated to handle phase-based regeneration parameters

### Frontend

- **GenerationPage.tsx**: Updated to pass phase-based regeneration parameters
- **AgentChat.tsx**: Updated regeneration modal to show which phases will be regenerated

## Phase Mapping

| Agent | Phase | Regenerates |
|-------|-------|-------------|
| Architect | Genesis | All phases |
| Profiler | Characters | Characters → Polish |
| Worldbuilder | Worldbuilding | Worldbuilding → Polish |
| Strategist | Outlining | Outlining → Polish |
| Writer | Drafting | Drafting → Polish |
| Critic/Polish | Polish | Polish only |

---

**Link to Devin run**: https://app.devin.ai/sessions/2350f21a86a640f6bdce06e24d3375ba

**Requested by**: Ilia Shalkin (mailtoshalkin@gmail.com) @IShalkin