### PR TITLE
fix: remove frontend from deploy workflow and increase wait time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,12 +28,8 @@ jobs:
             docker compose -f docker-compose.vps.yml build orchestrator
             docker compose -f docker-compose.vps.yml up -d orchestrator
             
-            # Rebuild and restart frontend
-            docker compose -f docker-compose.vps.yml build frontend
-            docker compose -f docker-compose.vps.yml up -d frontend
-            
-            # Wait for services to be healthy
-            sleep 10
+            # Wait for orchestrator to be healthy (container needs time to start)
+            sleep 30
             
             # Verify orchestrator is running
             curl -f http://localhost:8001/health || exit 1


### PR DESCRIPTION
## Summary

Fixes the deploy workflow that failed after merge.

## Changes

- Remove frontend build/deploy steps (frontend is deployed separately, not in docker-compose.vps.yml)
- Increase wait time from 10s to 30s for orchestrator to fully start before health check

## Link to Devin run

https://app.devin.ai/sessions/3e8a6b0e429e4afb872d1a6ca71fcac6

Requested by: Ilia Shalkin (mailtoshalkin@gmail.com) / @IShalkin