### PR TITLE
fix: use docker exec for health check in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
             # Wait for orchestrator to be healthy (container needs time to start)
             sleep 30
             
-            # Verify orchestrator is running
-            curl -f http://localhost:8001/health || exit 1
+            # Verify orchestrator is running (check inside container since it's not exposed on localhost)
+            docker exec manoe-orchestrator curl -f http://localhost:8001/health || exit 1
             
             echo "Deployment completed successfully!"


### PR DESCRIPTION
## Summary

Fixes the deploy workflow health check that was failing because the orchestrator is not exposed on localhost.

## Changes

- Use `docker exec manoe-orchestrator curl` to check health inside the container instead of trying to access localhost:8001 from the host

## Link to Devin run

https://app.devin.ai/sessions/3e8a6b0e429e4afb872d1a6ca71fcac6

Requested by: Ilia Shalkin (mailtoshalkin@gmail.com) / @IShalkin