### PR TITLE
chore: align README and env examples with current configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,34 +31,15 @@ GEMINI_API_KEY=your-gemini-api-key
 ANTHROPIC_API_KEY=sk-ant-your-anthropic-api-key
 
 # =============================================================================
-# Agent Model Configuration
-# Specify which provider and model each agent should use
+# Frontend (Vite)
 # =============================================================================
+# These variables are consumed by the frontend build/runtime.
+# When using docker-compose.yml, these are passed into the frontend container.
 
-# Architect Agent (Genesis Phase - transforms seed ideas into narratives)
-# Recommended: gpt-4o, claude-3-5-sonnet, gemini-1.5-pro
-ARCHITECT_PROVIDER=openai
-ARCHITECT_MODEL=gpt-4o
-
-# Profiler Agent (Character Design - creates psychological profiles)
-# Recommended: gpt-4o, claude-3-5-sonnet, gemini-1.5-pro
-PROFILER_PROVIDER=openai
-PROFILER_MODEL=gpt-4o
-
-# Strategist Agent (Plot Outlining - creates scene-by-scene outlines)
-# Recommended: gpt-4o, claude-3-5-sonnet, o1-preview
-STRATEGIST_PROVIDER=openai
-STRATEGIST_MODEL=gpt-4o
-
-# Writer Agent (Drafting - transforms outlines into prose)
-# Recommended: gpt-4o-mini, claude-3-5-haiku, gemini-1.5-flash (cost-effective)
-WRITER_PROVIDER=openai
-WRITER_MODEL=gpt-4o-mini
-
-# Critic Agent (Feedback - provides artistic critique)
-# Recommended: gpt-4o, claude-3-5-sonnet, gemini-1.5-pro
-CRITIC_PROVIDER=openai
-CRITIC_MODEL=gpt-4o
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+# Base URL for the API Gateway orchestrator endpoints
+VITE_ORCHESTRATOR_URL=http://localhost:3000/orchestrate
 
 # =============================================================================
 # Available Models by Provider
@@ -98,30 +79,31 @@ CRITIC_MODEL=gpt-4o
 # =============================================================================
 
 # =============================================================================
-# Generation Settings
+# API Gateway / Backend (used by docker-compose.vps.yml)
 # =============================================================================
 
-DEFAULT_TEMPERATURE=0.7
-MAX_RETRIES=3
-TIMEOUT_SECONDS=120
+# Supabase URL (Kong URL if self-hosted)
+SUPABASE_URL=
+
+# JWT token expiration
+JWT_EXPIRES_IN=7d
+
+# Langfuse (optional observability)
+LANGFUSE_HOST=
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+
+# Email used by nginx-proxy companion (docker-compose.vps.yml)
+LETSENCRYPT_EMAIL=
 
 # =============================================================================
 # Service Ports (change if you have conflicts)
 # =============================================================================
 
-API_PORT=3000
+FRONTEND_PORT=5173
 REDIS_PORT=6379
 QDRANT_PORT=6333
 QDRANT_GRPC_PORT=6334
-POSTGRES_PORT=5432
-
-# =============================================================================
-# Database Configuration
-# =============================================================================
-
-POSTGRES_USER=manoe
-POSTGRES_PASSWORD=manoe_password
-POSTGRES_DB=manoe
 
 # =============================================================================
 # Security (CHANGE IN PRODUCTION!)
@@ -146,8 +128,9 @@ QDRANT_API_KEY=
 # Logging
 # =============================================================================
 
-LOG_LEVEL=INFO
-NODE_ENV=production
+LOG_LEVEL=info
+# For api-gateway when running outside Docker.
+NODE_ENV=development
 # CORS_ORIGIN: Comma-separated list of allowed origins, or * for all
 # For production with local development: https://manoe.iliashalkin.com,http://localhost:5173
 CORS_ORIGIN=*

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ cd manoe
 cp .env.example .env
 # Edit .env with your API keys (at least one LLM provider required)
 
-# Start all services (local development)
-docker-compose up -d
+# Start frontend + Redis + Qdrant (local UI)
+docker compose up -d
 
-# Or start production-ready stack
+# Or start the full VPS stack (API Gateway + observability)
 docker compose -f docker-compose.vps.yml up -d --build
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     environment:
       - VITE_SUPABASE_URL=${VITE_SUPABASE_URL:-}
       - VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY:-}
-      - VITE_API_URL=${VITE_API_URL:-http://localhost:3000/api}
+      - VITE_ORCHESTRATOR_URL=${VITE_ORCHESTRATOR_URL:-http://localhost:3000/orchestrate}
     depends_on:
       redis:
         condition: service_healthy

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,8 +3,7 @@
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key-here
 
-# Qdrant Vector Database URL
-VITE_QDRANT_URL=http://localhost:6333
-
-# API Gateway URL
-VITE_API_URL=http://localhost:3000/api
+# API Gateway (Orchestrator) URL
+# This should point to the API Gateway's /orchestrate base path.
+# Local dev example: http://localhost:3000/orchestrate
+VITE_ORCHESTRATOR_URL=http://localhost:3000/orchestrate


### PR DESCRIPTION
### **User description**
This PR updates documentation/env examples to match the current repo configuration:

- Fix frontend env variable mismatch: use `VITE_ORCHESTRATOR_URL` (matches `frontend/src/lib/api.ts`) instead of unused `VITE_API_URL`
- Update `docker-compose.yml` to pass `VITE_ORCHESTRATOR_URL`
- Refresh root `.env.example` to include actually-used vars (`VITE_*`, `SUPABASE_URL`, `LANGFUSE_*`, `LETSENCRYPT_EMAIL`, `FRONTEND_PORT`) and remove unused/legacy ones (agent model vars, generation settings, postgres vars)
- Clarify README Quick Start: local `docker-compose.yml` brings up frontend + Redis + Qdrant; full stack is via `docker-compose.vps.yml`

No runtime code changes; documentation and environment templates only.

@IShalkin can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)




___

### **PR Type**
Documentation


___

### **Description**
- Removed unused agent model configuration variables from root `.env.example`

- Fixed frontend environment variable mismatch: replaced `VITE_API_URL` with `VITE_ORCHESTRATOR_URL`

- Updated `.env.example` to include actually-used variables (`VITE_*`, `SUPABASE_URL`, `LANGFUSE_*`, `LETSENCRYPT_EMAIL`, `FRONTEND_PORT`)

- Clarified README Quick Start: local `docker-compose.yml` for frontend + Redis + Qdrant; full stack via `docker-compose.vps.yml`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Developer reads .env.example"] -->|Previously had unused vars| B["Confusion about required config"]
  A -->|Now has actual vars| C["Clear understanding of setup"]
  D["docker-compose.yml"] -->|Previously VITE_API_URL| E["Frontend mismatch"]
  D -->|Now VITE_ORCHESTRATOR_URL| F["Matches frontend/src/lib/api.ts"]
  G["README Quick Start"] -->|Clarified| H["Local vs VPS stack distinction"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Remove unused vars, add actual configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.example

<ul><li>Removed unused agent model configuration (<code>ARCHITECT_PROVIDER</code>, <br><code>PROFILER_PROVIDER</code>, <code>STRATEGIST_PROVIDER</code>, <code>WRITER_PROVIDER</code>, <br><code>CRITIC_PROVIDER</code> and their model variants)<br> <li> Removed unused generation settings (<code>DEFAULT_TEMPERATURE</code>, <code>MAX_RETRIES</code>, <br><code>TIMEOUT_SECONDS</code>)<br> <li> Removed unused PostgreSQL configuration (<code>POSTGRES_USER</code>, <br><code>POSTGRES_PASSWORD</code>, <code>POSTGRES_DB</code>, <code>POSTGRES_PORT</code>)<br> <li> Added frontend-specific variables: <code>VITE_SUPABASE_URL</code>, <br><code>VITE_SUPABASE_ANON_KEY</code>, <code>VITE_ORCHESTRATOR_URL</code><br> <li> Added backend variables: <code>SUPABASE_URL</code>, <code>JWT_EXPIRES_IN</code>, <code>LANGFUSE_*</code> <br>(observability), <code>LETSENCRYPT_EMAIL</code><br> <li> Changed <code>API_PORT</code> to <code>FRONTEND_PORT</code> and updated port references<br> <li> Updated logging defaults: <code>LOG_LEVEL=info</code> and <code>NODE_ENV=development</code></ul>


</details>


  </td>
  <td><a href="https://github.com/IShalkin/manoe/pull/121/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+25/-42</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clarify local vs production stack setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated Quick Start instructions to clarify that <code>docker compose up -d</code> <br>starts frontend + Redis + Qdrant for local UI development<br> <li> Added note that <code>docker compose -f docker-compose.vps.yml up -d --build</code> <br>starts the full VPS stack with API Gateway and observability<br> <li> Changed command from <code>docker-compose</code> to <code>docker compose</code> (modern syntax)</ul>


</details>


  </td>
  <td><a href="https://github.com/IShalkin/manoe/pull/121/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Fix frontend environment variable mismatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Fixed frontend environment variable from <code>VITE_API_URL</code> to <br><code>VITE_ORCHESTRATOR_URL</code> to match actual usage in <code>frontend/src/lib/api.ts</code><br> <li> Updated default value from <code>http://localhost:3000/api</code> to <br><code>http://localhost:3000/orchestrate</code></ul>


</details>


  </td>
  <td><a href="https://github.com/IShalkin/manoe/pull/121/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Replace API_URL with ORCHESTRATOR_URL variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/.env.example

<ul><li>Removed unused <code>VITE_QDRANT_URL</code> variable (frontend does not access <br>Qdrant directly)<br> <li> Replaced <code>VITE_API_URL</code> with <code>VITE_ORCHESTRATOR_URL</code> to match actual code <br>usage<br> <li> Added clarifying comment explaining the orchestrator URL purpose and <br>local development example</ul>


</details>


  </td>
  <td><a href="https://github.com/IShalkin/manoe/pull/121/files#diff-7b3b2052ac3e484bcffbb75d7ee140a9ebe7677fd7ea34ac17ca193dd3c0ecfc">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes environment variable misalignment between documentation and actual code usage. The frontend code at `frontend/src/lib/api.ts:3` reads `VITE_ORCHESTRATOR_URL`, but the environment examples were incorrectly referencing `VITE_API_URL`. 

Key improvements:
- Replaced unused `VITE_API_URL` with `VITE_ORCHESTRATOR_URL` in `frontend/.env.example` and `docker-compose.yml`
- Removed legacy configuration variables from root `.env.example` (agent model settings, postgres vars, generation settings) that either belong in `docker-compose.vps.yml` or are documented separately in `docs/AGENTS.md`
- Added actually-used variables: `VITE_ORCHESTRATOR_URL`, `SUPABASE_URL`, `LANGFUSE_*`, `LETSENCRYPT_EMAIL`, `FRONTEND_PORT`
- Clarified README Quick Start: local `docker compose up` runs frontend + Redis + Qdrant only; full stack requires `docker-compose.vps.yml`

The changes ensure new developers can correctly configure their environment by following the examples.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it only updates documentation and environment variable examples
- This PR contains zero runtime code changes, only documentation updates. All changes align environment variable examples with actual codebase usage (VITE_ORCHESTRATOR_URL is used in frontend/src/lib/api.ts). The removed variables (agent model configs, postgres settings) are either documented in AGENTS.md or used only in docker-compose.vps.yml, not in the root .env.example
- No files require special attention - all changes are documentation-only

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .env.example | Removed legacy agent model configuration variables and generation settings; added actually-used frontend and backend variables (VITE_ORCHESTRATOR_URL, SUPABASE_URL, LANGFUSE_*, LETSENCRYPT_EMAIL, FRONTEND_PORT) |
| frontend/.env.example | Replaced unused VITE_API_URL and VITE_QDRANT_URL with VITE_ORCHESTRATOR_URL to match actual usage in frontend/src/lib/api.ts |
| docker-compose.yml | Updated frontend environment to pass VITE_ORCHESTRATOR_URL instead of unused VITE_API_URL |
| README.md | Clarified Quick Start instructions to distinguish local docker-compose.yml (frontend + Redis + Qdrant) from full VPS stack (docker-compose.vps.yml) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Env as .env.example
    participant Docker as docker-compose.yml
    participant Frontend as Frontend Container
    participant API as frontend/src/lib/api.ts
    
    Dev->>Env: 1. Copy .env.example to .env
    Dev->>Env: 2. Set VITE_ORCHESTRATOR_URL
    Dev->>Docker: 3. Run docker compose up
    Docker->>Frontend: Pass VITE_ORCHESTRATOR_URL env var
    Frontend->>API: Build with import.meta.env.VITE_ORCHESTRATOR_URL
    API->>API: Use ORCHESTRATOR_URL for API calls
    
    Note over Dev,API: Before this PR: VITE_API_URL was in examples<br/>but VITE_ORCHESTRATOR_URL was in code (mismatch)
    Note over Dev,API: After this PR: VITE_ORCHESTRATOR_URL in both<br/>examples and code (aligned)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->