### PR TITLE
feat(spice): opt-in spice-rewrite pass (Slice 2)

### DIFF
--- a/api-gateway/src/__tests__/SpiceConfigPlumbing.test.ts
+++ b/api-gateway/src/__tests__/SpiceConfigPlumbing.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Slice 2: SpiceConfig is an opt-in side config (default off). This pins its
+ * shape and that GenerationOptions accepts it as optional.
+ */
+import type { GenerationOptions, SpiceConfig } from "../agents/types";
+import { GenerationState } from "../models/AgentModels";
+
+describe("SpiceConfig type", () => {
+  it("accepts a fully-specified spice config on GenerationOptions", () => {
+    const spice: SpiceConfig = {
+      provider: "openrouter",
+      model: "some/uncensored-model",
+      apiKey: "sk-test",
+      ceiling: "explicit, consensual",
+    };
+    const opts: GenerationOptions = {
+      projectId: "p", seedIdea: "s",
+      llmConfig: { provider: "anthropic", model: "claude-opus-4-5", apiKey: "k" },
+      mode: "full",
+      spiceConfig: spice,
+    };
+    expect(opts.spiceConfig?.provider).toBe("openrouter");
+  });
+
+  it("is optional (absent is valid)", () => {
+    const opts: GenerationOptions = {
+      projectId: "p", seedIdea: "s",
+      llmConfig: { provider: "anthropic", model: "claude-opus-4-5", apiKey: "k" },
+      mode: "full",
+    };
+    expect(opts.spiceConfig).toBeUndefined();
+  });
+});
+
+describe("GenerationState.spiceRegions", () => {
+  it("initializes to an empty Map", () => {
+    const state = new GenerationState();
+    expect(state.spiceRegions instanceof Map).toBe(true);
+    expect(state.spiceRegions.size).toBe(0);
+  });
+});

--- a/api-gateway/src/__tests__/SpiceExtraction.test.ts
+++ b/api-gateway/src/__tests__/SpiceExtraction.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Slice 2: applySpiceExtraction stores regions on state and returns SOFT text.
+ * This is the seam the orchestrator uses right after the Writer returns.
+ */
+import { applySpiceExtraction } from "../services/spiceParser";
+import { GenerationState } from "../models/AgentModels";
+
+describe("applySpiceExtraction", () => {
+  it("stores regions for the scene and returns detagged soft text", () => {
+    const state = new GenerationState();
+    const raw = `A. {{SPICE style="x"}}B.{{/SPICE}} C.`;
+    const soft = applySpiceExtraction(state, 3, raw);
+    expect(soft).toBe("A. B. C.");
+    expect(state.spiceRegions.get(3)).toEqual([{ text: "B.", style: "x" }]);
+  });
+
+  it("stores nothing and returns unchanged text when there are no tags", () => {
+    const state = new GenerationState();
+    const soft = applySpiceExtraction(state, 1, "plain prose");
+    expect(soft).toBe("plain prose");
+    expect(state.spiceRegions.has(1)).toBe(false);
+  });
+});

--- a/api-gateway/src/__tests__/SpiceParser.test.ts
+++ b/api-gateway/src/__tests__/SpiceParser.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Slice 2: the spice parser extracts {{SPICE style="..."}}…{{/SPICE}} fragments
+ * and returns clean SOFT prose. It must never throw and never leak markup.
+ */
+import { extractSpiceRegions } from "../services/spiceParser";
+
+describe("extractSpiceRegions", () => {
+  it("extracts a single well-formed region and detags the prose", () => {
+    const raw = `She closed the door. {{SPICE style="slow burn"}}They moved closer.{{/SPICE}} Morning came.`;
+    const { soft, regions } = extractSpiceRegions(raw);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].text).toBe("They moved closer.");
+    expect(regions[0].style).toBe("slow burn");
+    expect(soft).toBe("She closed the door. They moved closer. Morning came.");
+    expect(soft).not.toContain("{{");
+  });
+
+  it("extracts multiple regions in order", () => {
+    const raw = `{{SPICE style="a"}}one{{/SPICE}} mid {{SPICE style="b"}}two{{/SPICE}}`;
+    const { soft, regions } = extractSpiceRegions(raw);
+    expect(regions.map((r) => r.text)).toEqual(["one", "two"]);
+    expect(regions.map((r) => r.style)).toEqual(["a", "b"]);
+    expect(soft).toBe("one mid two");
+  });
+
+  it("returns zero regions and unchanged prose when there are no tags", () => {
+    const { soft, regions } = extractSpiceRegions("Just plain prose.");
+    expect(regions).toHaveLength(0);
+    expect(soft).toBe("Just plain prose.");
+  });
+
+  it("strips an unclosed opening tag without leaking markup (keeps the text)", () => {
+    const raw = `Before {{SPICE style="x"}}the rest of the scene with no close`;
+    const { soft, regions } = extractSpiceRegions(raw);
+    expect(soft).not.toContain("{{");
+    expect(soft).not.toContain("SPICE");
+    expect(soft).toContain("the rest of the scene");
+    expect(regions).toHaveLength(0); // unclosed => not a usable region
+  });
+
+  it("strips an orphan closing tag", () => {
+    const { soft } = extractSpiceRegions("text {{/SPICE}} more");
+    expect(soft).not.toContain("{{");
+    expect(soft).toContain("text");
+    expect(soft).toContain("more");
+  });
+
+  it("handles a style-less opening tag (style defaults to empty string)", () => {
+    const { regions } = extractSpiceRegions(`{{SPICE}}body{{/SPICE}}`);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].text).toBe("body");
+    expect(regions[0].style).toBe("");
+  });
+
+  it("never throws on garbage input", () => {
+    expect(() => extractSpiceRegions(`{{SPICE {{ }} /SPICE}} {{SPICE style=}}`)).not.toThrow();
+    const { soft } = extractSpiceRegions(`{{SPICE {{ }} /SPICE}} {{SPICE style=}}`);
+    expect(soft).not.toContain("{{SPICE");
+  });
+
+  it("flattens nested SPICE by taking the outermost region's inner text", () => {
+    const raw = `{{SPICE style="outer"}}a {{SPICE style="inner"}}b{{/SPICE}} c{{/SPICE}}`;
+    const { soft, regions } = extractSpiceRegions(raw);
+    expect(soft).not.toContain("{{");
+    // At least one usable region; inner markup must not survive in soft text.
+    expect(regions.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("extractSpiceRegions — markup must never leak (adversarial)", () => {
+  it("handles a single } inside the style attribute without leaking the open tag", () => {
+    const { soft, regions } = extractSpiceRegions(`{{SPICE style="a}b"}}x{{/SPICE}}`);
+    expect(soft).toBe("x");
+    expect(soft).not.toContain("{{");
+    expect(soft).not.toContain("SPICE");
+    expect(regions).toHaveLength(1);
+    expect(regions[0].text).toBe("x");
+  });
+
+  it("never leaves any {{SPICE or {{/SPICE token in soft across nasty inputs", () => {
+    const nasty = [
+      `{{SPICE style="a}b"}}x{{/SPICE}}`,
+      `{{/SPICE}} {{SPICE}}y{{/SPICE}}`,
+      `{{ spice STYLE="z" }}body{{/ spice }}`,
+      `{{SPICE}}`,
+      `plain prose no tags`,
+      `{{SPICE style="x"}}unclosed tail with {{SPICE}} junk`,
+    ];
+    for (const input of nasty) {
+      const { soft } = extractSpiceRegions(input);
+      expect(soft).not.toMatch(/\{\{\s*\/?\s*SPICE/i);
+    }
+  });
+});

--- a/api-gateway/src/__tests__/SpicePassResilience.test.ts
+++ b/api-gateway/src/__tests__/SpicePassResilience.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression test for the Slice 2 terminal spice pass resilience contract.
+ *
+ * applySpicePass is an OPTIONAL, uncensored-model enhancement that runs AFTER a
+ * scene is already finalized in SOFT form. Its contract is: it must NEVER fail a
+ * scene. A failure in any of its side-effecting calls (notably the Redis-backed
+ * publishEvent calls, which are not internally guarded) must be swallowed so the
+ * already-finalized SOFT canon survives and the run is not marked ERROR.
+ *
+ * This test injects a redisStreams mock whose publishEvent throws, then asserts
+ * that applySpicePass RESOLVES (does not reject) and the soft draft.content is
+ * left untouched.
+ */
+
+// The third-party `langfuse` package does a dynamic import() at module-eval time,
+// which Jest's default VM cannot service. Mock our LangfuseService wrapper so the
+// real langfuse package is never required and the orchestrator loads. (Mirrors
+// the pattern in OrchestratorImport.test.ts.)
+jest.mock("../services/LangfuseService", () => ({
+  LangfuseService: class {
+    startTrace() {}
+    endTrace() {}
+    startSpan() { return "span"; }
+    endSpan() {}
+    addEvent() {}
+    trackLLMCall() {}
+    async getPrompt() { return { compile: () => "" }; }
+    recordUserFeedback() {}
+    recordRegenerationRequest() {}
+  },
+  AGENT_PROMPTS: {},
+  PHASE_PROMPTS: {},
+}));
+
+import { StorytellerOrchestrator } from "../services/StorytellerOrchestrator";
+
+describe("applySpicePass resilience", () => {
+  const SOFT_TEXT = "She crossed the room. The fragment was here. Then she left.";
+
+  function buildOrchestrator(publishEvent: jest.Mock) {
+    // Field-injected (@Inject) deps — assign the few applySpicePass touches.
+    const orchestrator = new StorytellerOrchestrator();
+
+    const llmProvider = {
+      createCompletionWithRetry: jest
+        .fn()
+        .mockResolvedValue({ content: "She crossed the room, slower this time." }),
+    };
+    const redisStreams = { publishEvent };
+    const supabase = { saveRunArtifact: jest.fn().mockResolvedValue(undefined) };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (orchestrator as any).llmProvider = llmProvider;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (orchestrator as any).redisStreams = redisStreams;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (orchestrator as any).supabase = supabase;
+
+    return { orchestrator, llmProvider, redisStreams, supabase };
+  }
+
+  function seedRun(orchestrator: StorytellerOrchestrator, runId: string, sceneNum: number) {
+    const draft: Record<string, unknown> = { content: SOFT_TEXT, wordCount: 12 };
+    const drafts = new Map<number, unknown>([[sceneNum, draft]]);
+    const spiceRegions = new Map<number, unknown[]>([
+      [sceneNum, [{ text: "The fragment was here.", style: "sensual" }]],
+    ]);
+
+    const state = {
+      runId,
+      drafts,
+      spiceRegions,
+      updatedAt: new Date().toISOString(),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (orchestrator as any).activeRuns.set(runId, state);
+    return { draft, state };
+  }
+
+  const options = {
+    projectId: "proj-1",
+    spiceConfig: {
+      provider: "openrouter",
+      model: "uncensored-model",
+      apiKey: "test-key",
+      ceiling: "explicit",
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  it("swallows a publishEvent (Redis) failure and keeps the soft text", async () => {
+    const publishEvent = jest.fn().mockRejectedValue(new Error("Redis hiccup"));
+    const { orchestrator } = buildOrchestrator(publishEvent);
+    const runId = "run-redis-fail";
+    const sceneNum = 1;
+    const { draft } = seedRun(orchestrator, runId, sceneNum);
+
+    // Call the private method via cast — must resolve, not reject.
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (orchestrator as any).applySpicePass(runId, options, sceneNum)
+    ).resolves.toBeUndefined();
+
+    // The very first publishEvent (scene_spice_start) threw — proves the throw path was hit.
+    expect(publishEvent).toHaveBeenCalled();
+    // Soft canon is intact; the pass did not corrupt the finalized draft.
+    expect(draft.content).toBe(SOFT_TEXT);
+  });
+
+  it("does not reject when publish succeeds on the success branch", async () => {
+    const publishEvent = jest.fn().mockResolvedValue(undefined);
+    const { orchestrator } = buildOrchestrator(publishEvent);
+    const runId = "run-ok";
+    const sceneNum = 2;
+    const { draft } = seedRun(orchestrator, runId, sceneNum);
+
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (orchestrator as any).applySpicePass(runId, options, sceneNum)
+    ).resolves.toBeUndefined();
+
+    // Soft content is preserved; amplification is stored separately under spicedContent.
+    expect(draft.content).toBe(SOFT_TEXT);
+  });
+});

--- a/api-gateway/src/__tests__/SpiceRewriter.test.ts
+++ b/api-gateway/src/__tests__/SpiceRewriter.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Slice 2: SpiceRewriter builds the amplify prompt and splices amplified text
+ * back into the final scene by exact match (graceful skip if not found).
+ */
+import { buildAmplifyMessages, spliceAmplified, contextAround } from "../services/SpiceRewriter";
+
+describe("buildAmplifyMessages", () => {
+  it("instructs amplify-not-replace and carries style, ceiling, and context", () => {
+    const msgs = buildAmplifyMessages({
+      fragment: "They moved closer.",
+      style: "slow burn to intense",
+      ceiling: "explicit, consensual",
+      before: "She locked the door.",
+      after: "Dawn broke.",
+    });
+    const joined = msgs.map((m) => m.content).join("\n").toLowerCase();
+    expect(joined).toContain("they moved closer");
+    expect(joined).toContain("slow burn to intense");
+    expect(joined).toContain("explicit, consensual");
+    expect(joined).toContain("she locked the door");
+    expect(joined).toContain("dawn broke");
+    expect(joined).toContain("preserve");
+  });
+});
+
+describe("spliceAmplified", () => {
+  it("replaces the exact fragment with the amplified text", () => {
+    const out = spliceAmplified("A. They moved closer. C.", "They moved closer.", "They drew together, breathless.");
+    expect(out).toBe("A. They drew together, breathless. C.");
+  });
+
+  it("returns the original text unchanged when the fragment is not found", () => {
+    const original = "A. Something else entirely. C.";
+    const out = spliceAmplified(original, "They moved closer.", "amplified");
+    expect(out).toBe(original);
+  });
+
+  it("replaces only the first occurrence", () => {
+    const out = spliceAmplified("x y x", "x", "Z");
+    expect(out).toBe("Z y x");
+  });
+});
+
+describe("contextAround", () => {
+  it("returns trimmed before/after windows around the fragment", () => {
+    const full = "AAA. The fragment here. BBB.";
+    const { before, after } = contextAround(full, "The fragment here.", 100);
+    expect(before).toBe("AAA.");
+    expect(after).toBe("BBB.");
+  });
+  it("returns empty strings when the fragment is not found", () => {
+    const { before, after } = contextAround("no match", "xyz", 100);
+    expect(before).toBe("");
+    expect(after).toBe("");
+  });
+});

--- a/api-gateway/src/__tests__/ValueShiftRestore.test.ts
+++ b/api-gateway/src/__tests__/ValueShiftRestore.test.ts
@@ -42,6 +42,7 @@ function makeState(runId: string): AnyObj {
     rawFactsLog: [], lastArchivistScene: 0, isPaused: false, isCompleted: false,
     inFlight: false, rollingSynopsis: [{ sceneNumber: 1, summary: "Scene 1 recap." }],
     valueShifts: new Map<number, number>([[1, -2], [2, 4]]),
+    spiceRegions: new Map<number, { text: string; style: string }[]>([[2, [{ text: "frag", style: "x" }]]]),
     startedAt: "", updatedAt: "",
   };
 }
@@ -75,5 +76,29 @@ describe("valueShifts survives snapshot → restore", () => {
     expect(vs.get(2)).toBe(4);
     // The write that used to crash must now work.
     expect(() => vs.set(3, 1)).not.toThrow();
+  });
+
+  it("serializes spiceRegions on shutdown and rehydrates it as a Map on restore", async () => {
+    const { orch, o, saved } = makeOrch();
+    const runId = "run-1";
+    o.activeRuns = new Map([[runId, makeState(runId)]]);
+
+    await (o.gracefulShutdown as (timeoutMs: number) => Promise<number>)(0);
+    expect(saved).toHaveLength(1);
+    const content = saved[0].content as AnyObj;
+    const persisted = JSON.parse(JSON.stringify(content)) as AnyObj;
+    expect(persisted.spiceRegions).toEqual({ "2": [{ text: "frag", style: "x" }] });
+
+    o.supabase = { getRunArtifact: jest.fn(async () => ({ content: persisted })) };
+    o.activeRuns = new Map();
+    const restored = await (o.restoreFromShutdown as (r: string) => Promise<number>)(runId);
+    expect(restored).toBe(1);
+
+    const state = (o.activeRuns as Map<string, AnyObj>).get(runId)!;
+    expect(state.spiceRegions instanceof Map).toBe(true);
+    const sr = state.spiceRegions as Map<number, { text: string; style: string }[]>;
+    expect(sr.get(2)).toEqual([{ text: "frag", style: "x" }]);
+    // The write that used to crash must now work.
+    expect(() => sr.set(3, [{ text: "more", style: "y" }])).not.toThrow();
   });
 });

--- a/api-gateway/src/__tests__/WriterSpiceTagging.test.ts
+++ b/api-gateway/src/__tests__/WriterSpiceTagging.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Slice 2: the Writer adds the {{SPICE}} tagging instruction to the DRAFTING
+ * prompt only when options.spiceConfig is present. Off by default.
+ */
+jest.mock("../services/LangfuseService", () => ({
+  LangfuseService: class {
+    startSpan() { return "s"; } endSpan() {} addEvent() {} trackLLMCall() {}
+    get isEnabled() { return false; }
+  },
+  AGENT_PROMPTS: {}, PHASE_PROMPTS: {},
+}));
+
+import { WriterAgent } from "../agents/WriterAgent";
+import { GenerationPhase } from "../models/LLMModels";
+
+type AnyObj = Record<string, unknown>;
+
+function makeWriter(): WriterAgent {
+  const langfuse = { isEnabled: false, startSpan: () => "s", endSpan: () => {}, addEvent: () => {}, trackLLMCall: () => {} } as unknown as ConstructorParameters<typeof WriterAgent>[1];
+  const llmProvider = {} as unknown as ConstructorParameters<typeof WriterAgent>[0];
+  return new WriterAgent(llmProvider, langfuse, undefined, undefined, { publishEvent: jest.fn(async () => "e") } as unknown as ConstructorParameters<typeof WriterAgent>[4]);
+}
+
+function draftContext(): AnyObj {
+  return {
+    runId: "r", projectId: "p",
+    state: {
+      currentScene: 3,
+      outline: { scenes: [{}, {}, { title: "The Crypt", wordCount: 800 }] },
+      currentSceneOutline: { title: "The Crypt", wordCount: 800, retrievedContext: "" },
+      keyConstraints: [],
+      characters: [{ name: "Mara", role: "lead" }],
+      worldState: {
+        runId: "r", lastUpdatedScene: 2, lastUpdatedAt: "",
+        characters: [], locations: [], organizations: [], timeline: [], keyFacts: [],
+      },
+      advancedPlan: { motifs: { shadow: "doubt" } },
+    },
+  };
+}
+
+function buildPrompt(writer: WriterAgent, context: AnyObj, options: AnyObj): string {
+  return (writer as unknown as {
+    buildUserPrompt(ctx: AnyObj, opts: AnyObj, phase: GenerationPhase): string;
+  }).buildUserPrompt(context, options, GenerationPhase.DRAFTING);
+}
+
+const baseOptions: AnyObj = {
+  projectId: "p", seedIdea: "s",
+  llmConfig: { provider: "anthropic", model: "m", apiKey: "k" },
+  mode: "full",
+};
+
+describe("WriterAgent spice tagging instruction", () => {
+  it("omits the tagging instruction when spiceConfig is absent (standard draft)", () => {
+    const prompt = buildPrompt(makeWriter(), draftContext(), baseOptions);
+    expect(prompt).not.toContain("{{SPICE");
+  });
+
+  it("includes the tagging instruction when spiceConfig is present (standard draft)", () => {
+    const opts = { ...baseOptions, spiceConfig: { provider: "openrouter", model: "x", apiKey: "k" } };
+    const prompt = buildPrompt(makeWriter(), draftContext(), opts);
+    expect(prompt).toContain("{{SPICE");
+    expect(prompt).toContain("{{/SPICE}}");
+  });
+
+  describe("beats first-part draft", () => {
+    function beatsContext(): AnyObj {
+      const c = draftContext();
+      const s = c.state as AnyObj;
+      s.currentSceneOutline = {
+        title: "The Crypt", wordCount: 800, retrievedContext: "",
+        beatsMode: true, partIndex: 1, partsTotal: 3, partTargetWords: 500,
+        isFirstPart: true,
+      };
+      return c;
+    }
+
+    it("omits the tagging instruction when spiceConfig is absent", () => {
+      const prompt = buildPrompt(makeWriter(), beatsContext(), baseOptions);
+      expect(prompt).not.toContain("{{SPICE");
+    });
+
+    it("includes the tagging instruction when spiceConfig is present", () => {
+      const opts = { ...baseOptions, spiceConfig: { provider: "openrouter", model: "x", apiKey: "k" } };
+      const prompt = buildPrompt(makeWriter(), beatsContext(), opts);
+      expect(prompt).toContain("{{SPICE");
+      expect(prompt).toContain("{{/SPICE}}");
+    });
+  });
+});

--- a/api-gateway/src/agents/WriterAgent.ts
+++ b/api-gateway/src/agents/WriterAgent.ts
@@ -165,6 +165,17 @@ Key Constraints: ${variables.keyConstraints || "No constraints established yet."
     const autonomousInstruction = `
 CRITICAL: Output ONLY the story prose. DO NOT ask questions. DO NOT offer options (A/B/C). DO NOT include meta-commentary like "Here is the scene" or "Which approach would you prefer". Just write the story content directly.`;
 
+    // Slice 2: only ask the model to tag intimate fragments when spice is enabled.
+    // With spice off this is "" and no {{SPICE}} markup is ever produced.
+    const spiceInstruction = options.spiceConfig
+      ? `
+SPICE TAGGING: If this scene contains an intimate/sexual passage, wrap ONLY that passage in spice tags so it can later be intensified:
+{{SPICE style="<short label of where the intimacy goes, e.g. 'tender to intense' or 'dom/sub escalation'>"}}
+...write the FULL passage at your normal strength here, including the dialogue, psychology, and build-up...
+{{/SPICE}}
+Write the passage completely and well — do NOT soften or skip it. Tag only the intimate fragment, not the whole scene. If the scene has no intimacy, do not emit any tags.`
+      : "";
+
     if (phase === GenerationPhase.DRAFTING) {
       const sceneNum = state.currentScene;
       const outline = state.outline as Record<string, unknown>;
@@ -238,7 +249,7 @@ Requirements:
 KEY CONSTRAINTS (MUST NOT VIOLATE):
 ${constraintsBlock}
 ${retrievedContext}
-${autonomousInstruction}`;
+${autonomousInstruction}${spiceInstruction}`;
         } else {
           // Continuation parts (2, 3, 4...)
           // Use 50 words of context (not 20) to maintain narrative voice and tone consistency
@@ -354,7 +365,7 @@ Requirements:
 KEY CONSTRAINTS (MUST NOT VIOLATE):
 ${constraintsBlock}
 ${retrievedContext}
-${autonomousInstruction}`;
+${autonomousInstruction}${spiceInstruction}`;
     }
 
     if (phase === GenerationPhase.REVISION) {
@@ -487,4 +498,3 @@ ${autonomousInstruction}`;
     return names.map(name => `- ${name}`).join("\n");
   }
 }
-

--- a/api-gateway/src/agents/types.ts
+++ b/api-gateway/src/agents/types.ts
@@ -17,6 +17,18 @@ export interface LLMConfiguration {
 }
 
 /**
+ * Opt-in spice configuration (Slice 2). When absent, the spice feature is inert:
+ * the Writer is not told to tag, and any stray {{SPICE}} markup is stripped.
+ * Routes the terminal amplify pass to an uncensored OpenRouter model.
+ */
+export interface SpiceConfig {
+  provider: string;   // typically "openrouter"
+  model: string;
+  apiKey: string;
+  ceiling?: string;   // base intensity ceiling (e.g. "explicit, consensual")
+}
+
+/**
  * Context passed to agent execute method
  */
 export interface AgentContext {
@@ -49,5 +61,5 @@ export interface GenerationOptions {
   llmConfig: LLMConfiguration;
   mode: "full" | "branching";
   settings?: Record<string, unknown>;
+  spiceConfig?: SpiceConfig;
 }
-

--- a/api-gateway/src/controllers/OrchestrationController.ts
+++ b/api-gateway/src/controllers/OrchestrationController.ts
@@ -28,7 +28,7 @@ import {
 } from "@tsed/schema";
 import { Inject } from "@tsed/di";
 import { Request, Response } from "express";
-import { randomUUID } from "crypto";
+import { v4 as uuidv4 } from "uuid";
 import { StorytellerOrchestrator, GenerationOptions, RunStatus } from "../services/StorytellerOrchestrator";
 import { RedisStreamsService } from "../services/RedisStreamsService";
 import { LLMProvider, GenerationPhase } from "../models/LLMModels";
@@ -315,7 +315,7 @@ Initiates a new narrative generation run. Returns immediately with a run ID.
   ): Promise<GenerateResponseDTO> {
     // Support both new TypeScript format and legacy Python format
     // Generate a proper UUID if no projectId is provided (Supabase expects UUID format)
-    const projectId = request.projectId || request.supabase_project_id || randomUUID();
+    const projectId = request.projectId || request.supabase_project_id || uuidv4();
     const seedIdea = request.seedIdea || request.seed_idea || "";
     const provider = request.llmConfig?.provider || request.provider as LLMProvider;
     const model = request.llmConfig?.model || request.model || "";

--- a/api-gateway/src/controllers/OrchestrationController.ts
+++ b/api-gateway/src/controllers/OrchestrationController.ts
@@ -116,7 +116,6 @@ class GenerateRequestDTO {
   settings?: Record<string, unknown>;
 
   @Property()
-  @Groups("internal")
   @Description("Opt-in spice rewrite config (default off)")
   spiceConfig?: SpiceConfigDTO;
 

--- a/api-gateway/src/controllers/OrchestrationController.ts
+++ b/api-gateway/src/controllers/OrchestrationController.ts
@@ -28,7 +28,7 @@ import {
 } from "@tsed/schema";
 import { Inject } from "@tsed/di";
 import { Request, Response } from "express";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "crypto";
 import { StorytellerOrchestrator, GenerationOptions, RunStatus } from "../services/StorytellerOrchestrator";
 import { RedisStreamsService } from "../services/RedisStreamsService";
 import { LLMProvider, GenerationPhase } from "../models/LLMModels";
@@ -63,6 +63,29 @@ class LLMConfigDTO {
 }
 
 /**
+ * Spice Configuration DTO (Slice 2) - opt-in side config, default off
+ */
+class SpiceConfigDTO {
+  @Required()
+  @Enum(LLMProvider)
+  @Description("Provider for the spice rewrite (typically openrouter)")
+  provider: LLMProvider;
+
+  @Required()
+  @Description("Uncensored model name on the provider")
+  model: string;
+
+  @Required()
+  @Groups("internal")
+  @Description("API key for the spice provider (BYOK)")
+  apiKey: string;
+
+  @Property()
+  @Description("Base intensity ceiling for amplification")
+  ceiling?: string;
+}
+
+/**
  * Generation Request DTO - supports both new TypeScript format and legacy Python format
  */
 class GenerateRequestDTO {
@@ -91,6 +114,11 @@ class GenerateRequestDTO {
   @Groups("internal")
   @Description("Additional settings")
   settings?: Record<string, unknown>;
+
+  @Property()
+  @Groups("internal")
+  @Description("Opt-in spice rewrite config (default off)")
+  spiceConfig?: SpiceConfigDTO;
 
   // Legacy Python format (snake_case)
   @Property()
@@ -287,7 +315,7 @@ Initiates a new narrative generation run. Returns immediately with a run ID.
   ): Promise<GenerateResponseDTO> {
     // Support both new TypeScript format and legacy Python format
     // Generate a proper UUID if no projectId is provided (Supabase expects UUID format)
-    const projectId = request.projectId || request.supabase_project_id || uuidv4();
+    const projectId = request.projectId || request.supabase_project_id || randomUUID();
     const seedIdea = request.seedIdea || request.seed_idea || "";
     const provider = request.llmConfig?.provider || request.provider as LLMProvider;
     const model = request.llmConfig?.model || request.model || "";
@@ -309,6 +337,7 @@ Initiates a new narrative generation run. Returns immediately with a run ID.
       mode,
       settings: request.settings,
       embeddingApiKey,
+      spiceConfig: request.spiceConfig,
     };
 
     try {

--- a/api-gateway/src/models/AgentModels.ts
+++ b/api-gateway/src/models/AgentModels.ts
@@ -151,7 +151,7 @@ export class KeyConstraint {
   value: string;
 
   @Optional()
-  @Property()
+  @Enum(AgentType)
   source?: AgentType;
 
   @Required()
@@ -184,7 +184,7 @@ export class RawFact {
   fact: string;
 
   @Required()
-  @Property()
+  @Enum(AgentType)
   source: AgentType;
 
   @Required()
@@ -322,6 +322,16 @@ export interface SceneContract {
 }
 
 /**
+ * A spice fragment extracted from a draft (Slice 2). `text` is the soft fragment
+ * the smart model wrapped; the terminal pass re-locates it in the final scene by
+ * exact match and amplifies it. `style` is the per-fragment intensity label.
+ */
+export interface SpiceRegion {
+  text: string;
+  style: string;
+}
+
+/**
  * Generation state tracking
  */
 export class GenerationState {
@@ -422,6 +432,14 @@ export class GenerationState {
    */
   @Property()
   valueShifts: Map<number, number> = new Map();
+
+  /**
+   * Per-scene spice fragments (Slice 2), extracted immediately after drafting and
+   * detagged from the prose before any gate runs. Empty unless spiceConfig is set
+   * and the Writer emitted {{SPICE}} tags. Keyed by scene number.
+   */
+  @Property()
+  spiceRegions: Map<number, SpiceRegion[]> = new Map();
 
   /**
    * Current scene outline being processed

--- a/api-gateway/src/models/AgentModels.ts
+++ b/api-gateway/src/models/AgentModels.ts
@@ -151,7 +151,7 @@ export class KeyConstraint {
   value: string;
 
   @Optional()
-  @Enum(AgentType)
+  @Property()
   source?: AgentType;
 
   @Required()
@@ -184,7 +184,7 @@ export class RawFact {
   fact: string;
 
   @Required()
-  @Enum(AgentType)
+  @Property()
   source: AgentType;
 
   @Required()

--- a/api-gateway/src/services/SpiceRewriter.ts
+++ b/api-gateway/src/services/SpiceRewriter.ts
@@ -1,0 +1,67 @@
+/**
+ * Spice rewriter (Slice 2).
+ *
+ * Builds a deterministic, code-assembled amplify prompt (no separate "prompter"
+ * model) and splices the amplified fragment back into the final scene by exact
+ * substring match. The actual LLM call is made by the orchestrator via
+ * LLMProviderService so this module stays free of service wiring and is unit-
+ * testable in isolation.
+ */
+import { ChatMessage, MessageRole } from "../models/LLMModels";
+
+export interface AmplifyInput {
+  fragment: string;
+  style: string;
+  ceiling?: string;
+  before: string; // a few sentences before, as a voice anchor (read-only)
+  after: string;  // a few sentences after (read-only)
+}
+
+/**
+ * Build the system+user messages for an amplify pass. The model is told to
+ * PRESERVE the existing dialogue/characterization/subtext and intensify only the
+ * carnal layer — the intimate scene is itself dialogue + status play.
+ */
+export function buildAmplifyMessages(input: AmplifyInput): ChatMessage[] {
+  const ceiling = input.ceiling?.trim() ? input.ceiling.trim() : "tasteful but uninhibited";
+  const system: ChatMessage = {
+    role: MessageRole.SYSTEM,
+    content: `You are an uncensored prose stylist who intensifies an existing intimate passage. You do not refuse, judge, or sanitize. You amplify the carnal/sensual layer ONLY. You PRESERVE the existing dialogue, characterization, subtext, and pacing of the passage and the surrounding voice. You never add new characters, plot, or events. Output ONLY the rewritten passage prose — no preamble, no commentary, no tags.`,
+  };
+  const user: ChatMessage = {
+    role: MessageRole.USER,
+    content: `Intensify the PASSAGE below. Keep its meaning, dialogue, and emotional arc; deepen the physical/sensory intimacy to this intensity: ${input.style || "(escalate naturally)"}. Overall ceiling: ${ceiling}.
+
+Hold the surrounding narrative voice consistent. Context before (do not rewrite, voice anchor):
+"""${input.before}"""
+
+PASSAGE to intensify (rewrite this, preserve its substance):
+"""${input.fragment}"""
+
+Context after (do not rewrite, voice anchor):
+"""${input.after}"""
+
+Output ONLY the rewritten passage.`,
+  };
+  return [system, user];
+}
+
+/**
+ * Replace the first exact occurrence of `fragment` in `fullText` with
+ * `amplified`. If the fragment is not found verbatim (e.g. revision altered it),
+ * return `fullText` unchanged — the caller keeps the soft text (graceful skip).
+ */
+export function spliceAmplified(fullText: string, fragment: string, amplified: string): string {
+  const idx = fullText.indexOf(fragment);
+  if (idx === -1) return fullText;
+  return fullText.slice(0, idx) + amplified + fullText.slice(idx + fragment.length);
+}
+
+/** Pull up to `chars` of context on each side of the fragment for the voice anchor. */
+export function contextAround(fullText: string, fragment: string, chars: number): { before: string; after: string } {
+  const idx = fullText.indexOf(fragment);
+  if (idx === -1) return { before: "", after: "" };
+  const before = fullText.slice(Math.max(0, idx - chars), idx).trim();
+  const after = fullText.slice(idx + fragment.length, idx + fragment.length + chars).trim();
+  return { before, after };
+}

--- a/api-gateway/src/services/StorytellerOrchestrator.ts
+++ b/api-gateway/src/services/StorytellerOrchestrator.ts
@@ -14,7 +14,7 @@
 
 import { Service, Inject } from "@tsed/di";
 import { $log } from "@tsed/common";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "crypto";
 import {
   GenerationPhase,
   LLMProvider,
@@ -29,6 +29,7 @@ import {
   KeyConstraint,
   RawFact,
   NarratorVoice,
+  SpiceRegion,
 } from "../models/AgentModels";
 import { LLMProviderService } from "./LLMProviderService";
 import { RedisStreamsService } from "./RedisStreamsService";
@@ -37,12 +38,14 @@ import { LangfuseService, AGENT_PROMPTS } from "./LangfuseService";
 import { SupabaseService, Character, Draft } from "./SupabaseService";
 import { MetricsService } from "./MetricsService";
 import { AgentFactory } from "../agents/AgentFactory";
-import { AgentContext } from "../agents/types";
+import { AgentContext, SpiceConfig } from "../agents/types";
 import { safeParseWordCount } from "../utils/schemaNormalizers";
 import { ArchivistAgent } from "../agents/ArchivistAgent";
 import { EvaluationService } from "./EvaluationService";
 import { WorldBibleEmbeddingService } from "./WorldBibleEmbeddingService";
 import { assembleSceneContract } from "./StoryStateAssembler";
+import { applySpiceExtraction } from "./spiceParser";
+import { buildAmplifyMessages, spliceAmplified, contextAround } from "./SpiceRewriter";
 
 /**
  * Simple rate limiter for concurrent async operations
@@ -103,6 +106,8 @@ export interface GenerationOptions {
   settings?: Record<string, unknown>;
   /** Embedding API key for WorldBibleEmbeddingService (Gemini API key) */
   embeddingApiKey?: string;
+  /** Opt-in spice rewrite config (Slice 2). Absent = feature off. */
+  spiceConfig?: SpiceConfig;
 }
 
 /**
@@ -150,6 +155,8 @@ interface SceneDraft {
   semanticCheckError?: string;
   /** Similarity score (0-1) - higher means more similar to World Bible entries */
   contradictionScore?: number;
+  /** Terminal spice-amplified version of `content` (Slice 2). Output to reader; never canon. */
+  spicedContent?: string;
   /** Index signature for compatibility with state.drafts Map and Qdrant storage */
   [key: string]: string | number | boolean | undefined;
 }
@@ -200,7 +207,7 @@ export class StorytellerOrchestrator {
    * @returns Run ID
    */
   async startGeneration(options: GenerationOptions): Promise<string> {
-    const runId = uuidv4();
+    const runId = randomUUID();
     process.stdout.write(`[StorytellerOrchestrator] startGeneration called, runId: ${runId}, projectId: ${options.projectId}\n`);
     $log.info(`[StorytellerOrchestrator] startGeneration called, runId: ${runId}, projectId: ${options.projectId}`);
 
@@ -221,6 +228,7 @@ export class StorytellerOrchestrator {
       rawFactsLog: [],
       rollingSynopsis: [],
       valueShifts: new Map(),
+      spiceRegions: new Map(),
       lastArchivistScene: 0,
       isPaused: false,
       isCompleted: false,
@@ -1037,6 +1045,13 @@ export class StorytellerOrchestrator {
         await this.emitSceneFinal(runId, options.projectId, sceneNum + 1, "flagged_subthreshold", finalScore);
       }
 
+      // Slice 2: terminal spice pass — runs after the scene is finalized in SOFT
+      // form (all gates passed on clean text). Inert unless spiceConfig is set and
+      // the scene produced spice regions. Never fails the scene.
+      if (!this.shouldStop(runId)) {
+        await this.applySpicePass(runId, options, sceneNum + 1);
+      }
+
       // Slice 2: thread the achieved value-shift (scene N exit → N+1 entry) and
       // append a rolling-synopsis entry for the finalized scene.
       // valueShiftDelivered comes from the last in-loop critique (the final
@@ -1123,7 +1138,10 @@ export class StorytellerOrchestrator {
 
     const output = await agent.execute(context, options);
     // Strip fake word count claims from Writer output (LLMs hallucinate word counts)
-    const response = this.stripFakeWordCount(output.content as string);
+    const rawResponse = this.stripFakeWordCount(output.content as string);
+    // Slice 2: extract spice fragments and DETAG before any gate sees the text.
+    // With spice off this only scrubs stray markup. SOFT text is the canon.
+    const response = applySpiceExtraction(state, sceneNum, rawResponse);
 
     const draft: SceneDraft = {
       sceneNum,
@@ -1368,6 +1386,11 @@ export class StorytellerOrchestrator {
         totalWordCount: combinedContent.split(/\s+/).length
       });
     }
+
+    // Slice 2: run spice extraction once over the FULL assembled scene so a region
+    // straddling a part boundary is reconciled. Detag before the draft is built so
+    // the SOFT text is what gets persisted and seen by every downstream gate.
+    combinedContent = applySpiceExtraction(state, sceneNum, combinedContent);
 
     // Create the final draft from combined content
     const draft: SceneDraft = {
@@ -1910,6 +1933,95 @@ export class StorytellerOrchestrator {
   }
 
   /**
+   * Slice 2 terminal spice pass. Runs AFTER the scene is finalized in SOFT form
+   * (already stored to Qdrant/Archivist). Only fires when spiceConfig is set and
+   * the scene has extracted regions. Amplifies each region via the uncensored
+   * provider, re-locates it in the final SOFT text by exact match, splices the
+   * amplified text in, stores spicedContent, and emits a replacement event.
+   * Any failure keeps the soft text (graceful degradation — never fails a scene).
+   */
+  private async applySpicePass(
+    runId: string,
+    options: GenerationOptions,
+    sceneNum: number
+  ): Promise<void> {
+    const spice = options.spiceConfig;
+    if (!spice) return;
+    const state = this.activeRuns.get(runId);
+    if (!state) return;
+    const regions = state.spiceRegions.get(sceneNum);
+    if (!regions || regions.length === 0) return;
+
+    const draft = state.drafts.get(sceneNum) as Record<string, unknown> | undefined;
+    const softText = typeof draft?.content === "string" ? draft.content : "";
+    if (!softText.trim()) return;
+
+    try {
+      await this.publishEvent(runId, "scene_spice_start", { sceneNum, regions: regions.length });
+
+      let spiced = softText;
+      let amplifiedCount = 0;
+      for (const region of regions) {
+        try {
+          const { before, after } = contextAround(spiced, region.text, 400);
+          const messages = buildAmplifyMessages({
+            fragment: region.text,
+            style: region.style,
+            ceiling: spice.ceiling,
+            before,
+            after,
+          });
+          const result = await this.llmProvider.createCompletionWithRetry({
+            messages,
+            model: spice.model,
+            provider: spice.provider as LLMProvider,
+            apiKey: spice.apiKey,
+            temperature: 0.9,
+            maxTokens: 4096,
+            runId,
+            agentName: "spice",
+          });
+          const amplified = (result.content ?? "").trim();
+          if (amplified.length > 0) {
+            const next = spliceAmplified(spiced, region.text, amplified);
+            if (next !== spiced) {
+              spiced = next;
+              amplifiedCount++;
+            }
+          }
+        } catch (spiceError) {
+          $log.warn(`[StorytellerOrchestrator] applySpicePass: region amplify failed for scene ${sceneNum}, keeping soft text, runId: ${runId}`, spiceError);
+        }
+      }
+
+      if (amplifiedCount === 0) {
+        await this.publishEvent(runId, "scene_spice_complete", { sceneNum, amplified: 0 });
+        return;
+      }
+
+      (draft as Record<string, unknown>).spicedContent = spiced;
+      state.drafts.set(sceneNum, draft as Record<string, unknown>);
+      state.updatedAt = new Date().toISOString();
+
+      await this.saveArtifact(runId, options.projectId, `spiced_scene_${sceneNum}`, {
+        sceneNum,
+        content: spiced,
+        wordCount: spiced.split(/\s+/).length,
+      });
+      await this.publishEvent(runId, "scene_spiced", {
+        sceneNum,
+        amplified: amplifiedCount,
+        finalContent: spiced,
+        wordCount: spiced.split(/\s+/).length,
+      });
+    } catch (spicePassError) {
+      // Optional enhancement: a failure here (e.g. Redis publish) must NEVER fail
+      // an already-finalized scene. Soft text remains the canon; just log and move on.
+      $log.warn(`[StorytellerOrchestrator] applySpicePass: spice pass failed for scene ${sceneNum}, keeping soft text, runId: ${runId}`, spicePassError);
+    }
+  }
+
+  /**
    * Validate polish output to prevent chunk loss and lazy polish notes
    * Returns true if polish is acceptable, false if we should fall back to pre-polish draft
    */
@@ -2082,6 +2194,7 @@ export class StorytellerOrchestrator {
         }
       }
     }
+
     console.log(`[extractRawFacts] Canonical names: ${Array.from(canonicalNames).join(', ')}`);
 
     // Patterns that capture meaningful character actions
@@ -2762,6 +2875,7 @@ Use Chain of Thought reasoning: IDENTIFY conflicts → RESOLVE by timestamp → 
           critiques: Object.fromEntries(state.critiques),
           revisionCount: Object.fromEntries(state.revisionCount),
           valueShifts: Object.fromEntries(state.valueShifts),
+          spiceRegions: Object.fromEntries(state.spiceRegions),
         };
 
         await this.supabase.saveRunArtifact({
@@ -2821,6 +2935,7 @@ Use Chain of Thought reasoning: IDENTIFY conflicts → RESOLVE by timestamp → 
         const critiquesObj = (savedState.critiques as Record<string, Record<string, unknown>[]>) || {};
         const revisionObj = (savedState.revisionCount as Record<string, number>) || {};
         const valueShiftsObj = (savedState.valueShifts as Record<string, number>) || {};
+        const spiceRegionsObj = (savedState.spiceRegions as Record<string, SpiceRegion[]>) || {};
 
         const state: GenerationState = {
           ...(savedState as unknown as GenerationState),
@@ -2835,6 +2950,9 @@ Use Chain of Thought reasoning: IDENTIFY conflicts → RESOLVE by timestamp → 
           ),
           valueShifts: new Map(
             Object.entries(valueShiftsObj).map(([k, v]) => [parseInt(k, 10), v])
+          ),
+          spiceRegions: new Map(
+            Object.entries(spiceRegionsObj).map(([k, v]) => [parseInt(k, 10), v])
           ),
           isPaused: true, // Keep paused until explicitly resumed
         };
@@ -2898,6 +3016,7 @@ Use Chain of Thought reasoning: IDENTIFY conflicts → RESOLVE by timestamp → 
           const critiquesObj = (savedState.critiques as Record<string, Record<string, unknown>[]>) || {};
           const revisionObj = (savedState.revisionCount as Record<string, number>) || {};
           const valueShiftsObj = (savedState.valueShifts as Record<string, number>) || {};
+          const spiceRegionsObj = (savedState.spiceRegions as Record<string, SpiceRegion[]>) || {};
 
           const state: GenerationState = {
             ...(savedState as unknown as GenerationState),
@@ -2914,6 +3033,9 @@ Use Chain of Thought reasoning: IDENTIFY conflicts → RESOLVE by timestamp → 
             ),
             valueShifts: new Map(
               Object.entries(valueShiftsObj).map(([k, v]) => [parseInt(k, 10), v])
+            ),
+            spiceRegions: new Map(
+              Object.entries(spiceRegionsObj).map(([k, v]) => [parseInt(k, 10), v])
             ),
             isPaused: true, // Keep paused until explicitly resumed
           };

--- a/api-gateway/src/services/spiceParser.ts
+++ b/api-gateway/src/services/spiceParser.ts
@@ -1,0 +1,90 @@
+/**
+ * Spice tag parser (Slice 2).
+ *
+ * The smart model marks intimate fragments inline:
+ *   {{SPICE style="..."}} ...fragment... {{/SPICE}}
+ *
+ * This module extracts those fragments to a side channel and returns the clean
+ * SOFT prose with all spice markup removed. It is the contract boundary with a
+ * stochastic model, so it is TOTAL: it never throws and never lets {{SPICE...}}
+ * or {{/SPICE}} markup survive into the returned text.
+ */
+
+import type { GenerationState, SpiceRegion } from "../models/AgentModels";
+
+export type { SpiceRegion } from "../models/AgentModels";
+
+const OPEN_RE = /\{\{\s*SPICE\b([\s\S]*?)\}\}/i;
+const CLOSE_RE = /\{\{\s*\/\s*SPICE\s*\}\}/i;
+const ANY_MARKUP_RE = /\{\{\s*\/?\s*SPICE\b[\s\S]*?\}\}/gi;
+
+function parseStyle(attrs: string): string {
+  const m = attrs.match(/style\s*=\s*"([^"]*)"/i);
+  return m ? m[1].trim() : "";
+}
+
+/**
+ * Extract well-formed (open…close) regions and return detagged soft prose.
+ * Malformed or unclosed markup is stripped from the soft text and produces no
+ * region. Nested opens are flattened (the outer region wins; inner markup is
+ * scrubbed from both the region text and the soft text).
+ */
+export function extractSpiceRegions(raw: string): { soft: string; regions: SpiceRegion[] } {
+  if (typeof raw !== "string" || raw.length === 0) {
+    return { soft: typeof raw === "string" ? raw : "", regions: [] };
+  }
+
+  const regions: SpiceRegion[] = [];
+  let soft = "";
+  let rest = raw;
+
+  // Greedy linear scan: find the next open, then its matching close.
+  // Guard the loop with a hard iteration cap so malformed input can never spin.
+  let guard = 0;
+  while (guard++ < 10000) {
+    const open = rest.match(OPEN_RE);
+    if (!open || open.index === undefined) break;
+
+    // Text before the open tag is clean soft prose.
+    soft += rest.slice(0, open.index);
+    const afterOpen = rest.slice(open.index + open[0].length);
+
+    const close = afterOpen.match(CLOSE_RE);
+    if (!close || close.index === undefined) {
+      // Unclosed open: drop the open tag, keep the trailing text as soft, stop.
+      rest = afterOpen;
+      break;
+    }
+
+    // Inner fragment text, with any nested SPICE markup scrubbed.
+    const innerRaw = afterOpen.slice(0, close.index);
+    const inner = innerRaw.replace(ANY_MARKUP_RE, "").trim();
+    if (inner.length > 0) {
+      regions.push({ text: inner, style: parseStyle(open[1]) });
+      soft += inner;
+    }
+    rest = afterOpen.slice(close.index + close[0].length);
+  }
+
+  soft += rest;
+  // Final safety net: scrub any markup that survived (orphan closes, garbage).
+  soft = soft.replace(ANY_MARKUP_RE, "");
+  return { soft, regions };
+}
+
+/**
+ * Orchestrator seam: extract regions from a freshly drafted scene, store any
+ * found regions on state (keyed by scene), and return the SOFT (detagged) text.
+ * Pure aside from the single state.spiceRegions write. Never throws.
+ */
+export function applySpiceExtraction(
+  state: GenerationState,
+  sceneNum: number,
+  raw: string
+): string {
+  const { soft, regions } = extractSpiceRegions(raw);
+  if (regions.length > 0) {
+    state.spiceRegions.set(sceneNum, regions);
+  }
+  return soft;
+}


### PR DESCRIPTION
**Closing as obsolete — superseded by #148.**

The spice-rewrite feature (Slice 2) already landed on `main` via #148 (merge commit `309a43e`), because both this work and #148 shared the `fix/orchestrator-bug-sweep` branch. This PR's branch (`feat/spice-rewrite`) forked from an older point and is now *behind* `main`: its diff vs `main` is net **−216 lines** and would revert newer work already merged (AnthropicCacheControl / ValueShiftThreading tests, LLMProviderService, QdrantMemoryService, WorldBibleEmbeddingService, etc.). Merging it would be a regression, so it must not be merged.

One thing from this PR was **not** in #148: the P0 fix making `spiceConfig` reachable through the API (`#148` merged the spice code at a commit predating that fix, so `main` currently ships the feature with `@Groups("internal")` on the request field — meaning it can never be activated). That one-line fix is being carried to `main` in a dedicated PR instead. See follow-up PR.

Identified by cubic. Closing here.