### PR TITLE
fix(spice): make spiceConfig reachable via /generate (cubic P0)

### DIFF
--- a/api-gateway/src/controllers/OrchestrationController.ts
+++ b/api-gateway/src/controllers/OrchestrationController.ts
@@ -116,7 +116,6 @@ class GenerateRequestDTO {
   settings?: Record<string, unknown>;
 
   @Property()
-  @Groups("internal")
   @Description("Opt-in spice rewrite config (default off)")
   spiceConfig?: SpiceConfigDTO;
 


### PR DESCRIPTION
## Problem

The spice-rewrite feature shipped to `main` via #148, but at a commit that predated the P0 fix — so the feature is currently **dead on arrival**: it can never be activated through the API.

`GenerateRequestDTO.spiceConfig` carries `@Groups("internal")`, and the `/generate` endpoint deserializes the body with `@BodyParams() @Groups("!internal")`, which strips all top-level internal-group fields. Result: `request.spiceConfig` is always `undefined`, the orchestrator never receives a spice config, the Writer never emits `{{SPICE}}` tags, and the terminal amplify pass returns at its first guard. The entire opt-in pipeline is unreachable.

(Originally identified by cubic on #149.)

## Fix

One line: remove `@Groups("internal")` from the **top-level** `spiceConfig` request field, mirroring how `llmConfig` already works. The nested `apiKey` inside `SpiceConfigDTO` keeps `@Groups("internal")` — nested fields are not stripped by the top-level group filter, so the key still stays redacted from serialized responses while the config is actually read from the request.

```diff
   @Property()
-  @Groups("internal")
   @Description("Opt-in spice rewrite config (default off)")
   spiceConfig?: SpiceConfigDTO;
```

## Verification

Applied the same change locally: `npm run typecheck` clean; all 7 spice suites pass (30/30), including `SpiceConfigPlumbing` which pins the `SpiceConfig` shape on `GenerationOptions`. No behavior change when `spiceConfig` is omitted (feature stays default-off).

## Note

This is the only piece of PR #149 that was missing from `main`. #149 itself was closed as obsolete — its branch had fallen behind `main` and merging it would have reverted newer work. The remaining cubic P2s now live on `main` (e.g. `valueShiftDelivered` range, `statusShifts` loose typing, `buildVoiceExemplarsBlock` empty-present, beats-continuation context injection) are non-blocking and can be addressed in a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `spiceConfig` to be read by `/generate`, unblocking the opt-in spice rewrite. Removed `@Groups("internal")` from the top-level `GenerateRequestDTO.spiceConfig` (matching `llmConfig`); the nested `apiKey` keeps `@Groups("internal")` so it remains redacted.

<sup>Written for commit 58c104629a66be2488979622c146dda6bb495f30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/IShalkin/manoe/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

